### PR TITLE
Using `serialize-xml` version with proper escaping.

### DIFF
--- a/routes/api/feeds/[seriesId].ts
+++ b/routes/api/feeds/[seriesId].ts
@@ -1,7 +1,7 @@
 import { nrkRadio, Episode } from "../../../lib/nrk.ts"
 import { HandlerContext } from "$fresh/server.ts";
 
-import { serialize, tag, declaration } from "https://raw.githubusercontent.com/olaven/serialize-xml/master/mod.ts";
+import { serialize, tag, declaration } from "https://raw.githubusercontent.com/olaven/serialize-xml/v0.4.0/mod.ts";
 
 function toItemTag(episode: Episode) {
     const description = episode.titles.subtitle || "";

--- a/routes/api/feeds/[seriesId].ts
+++ b/routes/api/feeds/[seriesId].ts
@@ -1,7 +1,7 @@
 import { nrkRadio, Episode } from "../../../lib/nrk.ts"
 import { HandlerContext } from "$fresh/server.ts";
 
-import { serialize, tag, declaration } from "https://deno.land/x/serializexml@v0.3.2/mod.ts";
+import { serialize, tag, declaration } from "https://raw.githubusercontent.com/olaven/serialize-xml/master/mod.ts";
 
 function toItemTag(episode: Episode) {
     const description = episode.titles.subtitle || "";


### PR DESCRIPTION
Closes #6. 

Upgrades to [the latest version of serialize-xml](https://github.com/olaven/serialize-xml/releases/tag/v0.4.0). This version automatically escapes XML tag value and content. 