### PR TITLE
Do not write to DB if there aren't new episodes

### DIFF
--- a/lib/caching.ts
+++ b/lib/caching.ts
@@ -20,6 +20,10 @@ async function updateFetch(existingSeries: Series) {
     return !existingSeries.episodes.find((serieEpisode) => serieEpisode.id === episode.id);
   });
 
+  if (newEpisodes.length === 0) {
+    return existingSeries;
+  }
+
   const updated = {
     ...existingSeries,
     lastFetch: new Date(),


### PR DESCRIPTION
We currently do a lot of unessecary DB writes.
This PR should fix that. This is important because it can get expensive rather quickly.