### PR TITLE
feat: Add open in podcast app button (and minor stuff)

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,31 @@
+import { ComponentChildren, JSX } from "preact";
+
+type ButtonProps = {
+  children: ComponentChildren;
+} & JSX.HTMLAttributes<HTMLButtonElement>;
+
+const className = "p-2 border(gray-100 2) hover:bg-gray-200 bg-blue-200 w-max font-medium";
+
+export function Button(props: ButtonProps) {
+  const { children, className: additionalClass = "", ...buttonProps } = props;
+
+  return (
+    <button className={`${className} ${additionalClass}`} {...buttonProps}>
+      {children}
+    </button>
+  );
+}
+
+type AnchorProps = {
+  children: ComponentChildren;
+} & JSX.HTMLAttributes<HTMLAnchorElement>;
+
+export function ButtonLink(props: AnchorProps) {
+  const { children, className: additionalClass = "", ...linkProps } = props;
+
+  return (
+    <a className={`${className} ${additionalClass}`} {...linkProps}>
+      {children}
+    </a>
+  );
+}

--- a/components/SeriesCard.tsx
+++ b/components/SeriesCard.tsx
@@ -1,6 +1,7 @@
 import CopyButton from "../islands/CopyButton.tsx";
 import { SearchResult } from "../lib/nrk/nrk.ts";
 import { ButtonLink } from "./Button.tsx";
+import IconPodcast from "https://deno.land/x/tabler_icons_tsx@0.0.5/tsx/brand-apple-podcast.tsx";
 
 export default function SeriesCard(props: { serie: SearchResult; origin: string }) {
   const feedUrl = new URL(`/api/feeds/${props.serie.seriesId}`, props.origin);
@@ -11,11 +12,11 @@ export default function SeriesCard(props: { serie: SearchResult; origin: string 
         <h3 className="text-xl font-semibold">{props.serie.title}</h3>
         <p className="text-md">{props.serie.description}</p>
         <img src={image.uri} width={image.width} alt="" />
-        <ButtonLink href={`podcast:${feedUrl.toString()}`} className="block">
-          📻 Åpne i din podkast-app
+        <ButtonLink href={`podcast:${feedUrl.toString()}`} className="block flex items-center gap-2">
+          <IconPodcast /> Åpne i din podkast-app
         </ButtonLink>
         <div className="w-full flex">
-          <CopyButton copyText={feedUrl.toString()} className="whitespace-nowrap">
+          <CopyButton copyText={feedUrl.toString()} className="whitespace-nowrap flex items-center gap-2">
             Kopier URL
           </CopyButton>
           <pre className="w-full font-mono bg-black text-white select-all p-2 overflow-x-auto">

--- a/components/SeriesCard.tsx
+++ b/components/SeriesCard.tsx
@@ -14,11 +14,13 @@ export default function SeriesCard(props: { serie: SearchResult; origin: string 
         <ButtonLink href={`podcast:${feedUrl.toString()}`} className="block">
           📻 Åpne i din podkast-app
         </ButtonLink>
-        <div className="">
-          <code className="font-mono bg-black text-white select-all p-2">{feedUrl.toString()}</code>
-          <CopyButton text={feedUrl.toString()}>
+        <div className="w-full flex">
+          <CopyButton copyText={feedUrl.toString()} className="whitespace-nowrap">
             Kopier URL
           </CopyButton>
+          <pre className="w-full font-mono bg-black text-white select-all p-2 overflow-x-auto">
+            {feedUrl.toString()}
+          </pre>
         </div>
       </div>
     </div>

--- a/components/SeriesCard.tsx
+++ b/components/SeriesCard.tsx
@@ -1,5 +1,6 @@
 import CopyButton from "../islands/CopyButton.tsx";
 import { SearchResult } from "../lib/nrk/nrk.ts";
+import { ButtonLink } from "./Button.tsx";
 
 export default function SeriesCard(props: { serie: SearchResult; origin: string }) {
   const feedUrl = new URL(`/api/feeds/${props.serie.seriesId}`, props.origin);
@@ -10,12 +11,9 @@ export default function SeriesCard(props: { serie: SearchResult; origin: string 
         <h3 className="text-xl font-semibold">{props.serie.title}</h3>
         <p className="text-md">{props.serie.description}</p>
         <img src={image.uri} width={image.width} alt="" />
-        <a
-          className="block w-max bg-blue-100 text-black p-2 border-black border"
-          href={`podcast:${feedUrl.toString()}`}
-        >
+        <ButtonLink href={`podcast:${feedUrl.toString()}`} className="block">
           📻 Åpne i din podkast-app
-        </a>
+        </ButtonLink>
         <div className="">
           <code className="font-mono bg-black text-white select-all p-2">{feedUrl.toString()}</code>
           <CopyButton text={feedUrl.toString()}>

--- a/components/SeriesCard.tsx
+++ b/components/SeriesCard.tsx
@@ -10,10 +10,18 @@ export default function SeriesCard(props: { serie: SearchResult; origin: string 
         <h3 className="text-xl font-semibold">{props.serie.title}</h3>
         <p className="text-md">{props.serie.description}</p>
         <img src={image.uri} width={image.width} alt="" />
-        <code className="font-mono bg-black text-white select-all p-2">{feedUrl.toString()}</code>
-        <CopyButton text={feedUrl.toString()}>
-          Kopier URL
-        </CopyButton>
+        <a
+          className="block w-max bg-blue-100 text-black p-2 border-black border"
+          href={`podcast:${feedUrl.toString()}`}
+        >
+          📻 Åpne i din podkast-app
+        </a>
+        <div className="">
+          <code className="font-mono bg-black text-white select-all p-2">{feedUrl.toString()}</code>
+          <CopyButton text={feedUrl.toString()}>
+            Kopier URL
+          </CopyButton>
+        </div>
       </div>
     </div>
   );

--- a/islands/CopyButton.tsx
+++ b/islands/CopyButton.tsx
@@ -13,7 +13,7 @@ type Props = {
 } & JSX.HTMLAttributes<HTMLButtonElement>;
 
 export default function CopyButton(props: Props) {
-  const { copyText, disabled = false, children, ...buttonProps } = props;
+  const { copyText, disabled = false, children, className = "", ...buttonProps } = props;
   const [clicked, setClicked] = useState(false);
 
   const startReset = () => {
@@ -30,6 +30,7 @@ export default function CopyButton(props: Props) {
         startReset();
       }}
       disabled={!IS_BROWSER || disabled}
+      className={`${className} ${clicked ? "bg-green-500" : ""}`}
       {...buttonProps}
     >
       {clicked

--- a/islands/CopyButton.tsx
+++ b/islands/CopyButton.tsx
@@ -2,6 +2,9 @@ import { ComponentChildren, JSX } from "preact";
 import { useState } from "preact/hooks";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { Button } from "../components/Button.tsx";
+import IconCopy from "https://deno.land/x/tabler_icons_tsx@0.0.5/tsx/copy.tsx";
+// BUG: We have to use the GitHub URL until they resolve the issue: https://github.com/hashrock/tabler-icons-tsx/issues/16
+import IconCopyCheck from "https://raw.githubusercontent.com/hashrock/tabler-icons-tsx/df5d89c516984fde5c8ec8a382a1348f9fa1aee6/tsx/copy-check.tsx";
 
 type Props = {
   copyText: string;
@@ -29,7 +32,17 @@ export default function CopyButton(props: Props) {
       disabled={!IS_BROWSER || disabled}
       {...buttonProps}
     >
-      {clicked ? "Kopiert!" : children}
+      {clicked
+        ? (
+          <>
+            <IconCopyCheck /> Kopiert!
+          </>
+        )
+        : (
+          <>
+            <IconCopy /> {children}
+          </>
+        )}
     </Button>
   );
 }

--- a/islands/CopyButton.tsx
+++ b/islands/CopyButton.tsx
@@ -1,14 +1,16 @@
-import Preact from "preact";
+import { ComponentChildren, JSX } from "preact";
 import { useState } from "preact/hooks";
 import { IS_BROWSER } from "$fresh/runtime.ts";
+import { Button } from "../components/Button.tsx";
 
 type Props = {
-  text: string;
-  children: Preact.ComponentChildren;
+  copyText: string;
+  children: ComponentChildren;
   disabled?: boolean;
-};
+} & JSX.HTMLAttributes<HTMLButtonElement>;
 
-export default function CopyButton({ text, disabled = false, children }: Props) {
+export default function CopyButton(props: Props) {
+  const { copyText, disabled = false, children, ...buttonProps } = props;
   const [clicked, setClicked] = useState(false);
 
   const startReset = () => {
@@ -18,16 +20,16 @@ export default function CopyButton({ text, disabled = false, children }: Props) 
   };
 
   return (
-    <button
+    <Button
       onClick={() => {
-        navigator.clipboard.writeText(text.toString());
+        navigator.clipboard.writeText(copyText.toString());
         setClicked(true);
         startReset();
       }}
       disabled={!IS_BROWSER || disabled}
-      class="px-2 py-1 border(gray-100 2) hover:bg-gray-200 mx-auto bg-blue-200"
+      {...buttonProps}
     >
       {clicked ? "Kopiert!" : children}
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
- **feat: Add open in podcast-app button**
- **feat: Add Button-component**
- **style: Add overflow to URL**
- **style: Add icons**
- **style: Change clicked bg color**

<details>
<summary>Before on mobile</summary>
<img width="479" alt="image" src="https://github.com/olaven/nrss/assets/5453010/dcad8f00-a980-4c97-ac4b-71d60f37c481">

</details>

<details>
<summary>After on mobile</summary>
<img width="534" alt="image" src="https://github.com/olaven/nrss/assets/5453010/a39bf253-d3d7-43dc-9628-e0d80bcf8caf">

</details>
