### PR TITLE
Fix invalid feed characters

### DIFF
--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals, assertNotEquals } from "$std/assert/mod.ts";
+import { responseJSON, responseXML } from "./utils.ts";
+
+Deno.test("JSON response is stringified", async () => {
+  const body = { message: "Hello, World!" };
+  const response = responseJSON(body, 200);
+  assertEquals(await response.text(), JSON.stringify(body));
+});
+
+Deno.test("XML resopnse is _not_ stringified", async () => {
+  const body = "<message>Hello, World!</message>";
+  const response = responseXML(body, 200);
+  const responseBody = await response.text();
+  assertEquals(responseBody, body);
+  assertNotEquals(responseBody, JSON.stringify(body));
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,15 +14,16 @@ type EnumValues<T> = T[keyof T];
 type Status = EnumValues<typeof STATUS_CODE>;
 
 export function responseJSON(body: unknown | null, status: Status) {
-  return response(body, status, "json");
+  const stringifiedBody = JSON.stringify(body);
+  return response(stringifiedBody, status, "json");
 }
 
-export function responseXML(body: unknown | null, status: Status) {
+export function responseXML(body: string, status: Status) {
   return response(body, status, "xml");
 }
 
-function response(body: unknown | null, status: number, type: "json" | "xml") {
-  return new Response(JSON.stringify(body), {
+function response(body: string, status: number, type: "json" | "xml") {
+  return new Response(body, {
     status,
     headers: {
       "Content-Type": `application/${type}`,

--- a/routes/api/feeds/[seriesId].ts
+++ b/routes/api/feeds/[seriesId].ts
@@ -11,6 +11,10 @@ export const handler = async (_req: Request, ctx: FreshContext): Promise<Respons
     return responseJSON({ message: "Series not found" }, STATUS_CODE.NotFound);
   }
   const feed = rss.assembleFeed(series);
+  console.log(feed);
 
-  return responseXML(feed, STATUS_CODE.OK);
+  const xml = responseXML(feed, STATUS_CODE.OK);
+  console.log({ feed, xml });
+
+  return xml;
 };

--- a/routes/api/feeds/[seriesId].ts
+++ b/routes/api/feeds/[seriesId].ts
@@ -11,7 +11,6 @@ export const handler = async (_req: Request, ctx: FreshContext): Promise<Respons
     return responseJSON({ message: "Series not found" }, STATUS_CODE.NotFound);
   }
   const feed = rss.assembleFeed(series);
-  console.log(feed);
 
   const xml = responseXML(feed, STATUS_CODE.OK);
   console.log({ feed, xml });

--- a/routes/api/feeds/[seriesId].ts
+++ b/routes/api/feeds/[seriesId].ts
@@ -13,7 +13,6 @@ export const handler = async (_req: Request, ctx: FreshContext): Promise<Respons
   const feed = rss.assembleFeed(series);
 
   const xml = responseXML(feed, STATUS_CODE.OK);
-  console.log({ feed, xml });
 
   return xml;
 };


### PR DESCRIPTION
This PR fixes a (sneaky) bug introduced in #25.
XML strings were stringified before being returned to the client, producing invalid XML ("'<></>'" over "<></>").
This PR changes the code such that only JSON responses are stringified.