### PR TITLE
Move promotion below description

### DIFF
--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -61,11 +61,7 @@ function descriptionWithDonationPromotion(description: string): string {
   const promotion =
     `Takk for at du bruker NRSS 🙏🌟 Vurder å støtte utviklingen via Vipps med omtrent det samme som prisen på en kaffekopp. Se mer på https://nrss.deno.dev/`;
 
-  return `
-  ${promotion}                    \n
-  --------------------------------\n
-  ${description}
-  `;
+  return `${description}\n\n${promotion}`;
 }
 
 function assembleEpisode(episode: Episode, seriesId: Series["id"]): Tag {


### PR DESCRIPTION
First, thanks for creating and hosting NRSS! Please disregard this change if you don't agree.

I fully understand that you want contribution/donations, my only issue is that now with the promotional text before the original description it's harder to get an overview of what each episode is about (in some players I guess).
![IMG_3DE36EDF11D2-1](https://github.com/user-attachments/assets/6c49dd50-8726-4311-972c-f93c39e8b933)

Hopefully people that care about the description read your promotion regardless if it's first or last. 