### PR TITLE
Add a second promo text to the front.

### DIFF
--- a/lib/rss.test.ts
+++ b/lib/rss.test.ts
@@ -38,12 +38,12 @@ Deno.test("generated rss contains promo with link to donations page", () => {
   const feed = rss.assembleFeed(series);
 
   const indexOfFirstPromotion = feed.indexOf(
-    "NRSS er avhengig av din Vipps-støtte"
+    "NRSS er avhengig av din Vipps-støtte",
   );
   const indexOfSecondPromotion = feed.indexOf("Vurder å støtte utviklingen");
   assertLess(
     indexOfFirstPromotion,
     indexOfSecondPromotion,
-    "First promotion should come before the second"
+    "First promotion should come before the second",
   );
 });

--- a/lib/rss.test.ts
+++ b/lib/rss.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "$std/assert/mod.ts";
+import { assertEquals, assertExists, assertLess } from "$std/assert/mod.ts";
 import { testUtils } from "./test-utils.ts";
 import { rss } from "./rss.ts";
 import { forTestingOnly } from "./rss.ts";
@@ -30,6 +30,20 @@ Deno.test("generated rss contains promo with link to donations page", () => {
   const series = testUtils.generateSeries();
   const feed = rss.assembleFeed(series);
 
-  console.log(feed);
   feed.includes("Vurder å støtte utviklingen via Vipps");
+});
+
+Deno.test("generated rss contains promo with link to donations page", () => {
+  const series = testUtils.generateSeries();
+  const feed = rss.assembleFeed(series);
+
+  const indexOfFirstPromotion = feed.indexOf(
+    "NRSS er avhengig av din Vipps-støtte"
+  );
+  const indexOfSecondPromotion = feed.indexOf("Vurder å støtte utviklingen");
+  assertLess(
+    indexOfFirstPromotion,
+    indexOfSecondPromotion,
+    "First promotion should come before the second"
+  );
 });

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -27,24 +27,21 @@ function assembleFeed(series: Series): string {
             tag("itunes:name", "NRK"),
             tag("itunes:email", "nrkpodcast@nrk.no"),
           ]),
-          tag(
-            "description",
-            series.subtitle || "",
-          ),
+          tag("description", series.subtitle || ""),
           tag("ttl", "60"), //60 minutes
           ...(series.imageUrl
             ? [
-              tag("itunes:image", "", [
-                ["href", series.imageUrl],
-              ]),
-              tag("image", [
-                tag("url", series.imageUrl),
-                tag("title", series.title),
-                tag("link", series.link),
-              ]),
-            ]
+                tag("itunes:image", "", [["href", series.imageUrl]]),
+                tag("image", [
+                  tag("url", series.imageUrl),
+                  tag("title", series.title),
+                  tag("link", series.link),
+                ]),
+              ]
             : []),
-          ...series.episodes.map((episode) => assembleEpisode(episode, series.id)),
+          ...series.episodes.map((episode) =>
+            assembleEpisode(episode, series.id)
+          ),
         ]),
       ],
       [
@@ -52,16 +49,16 @@ function assembleFeed(series: Series): string {
         ["xmlns:itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"],
         ["xmlns:content", "http://purl.org/rss/1.0/modules/content/"],
         ["xmlns:podcast", "https://podcastindex.org/namespace/1.0"],
-      ],
-    ),
+      ]
+    )
   );
 }
 
 function descriptionWithDonationPromotion(description: string): string {
-  const promotion =
-    `Takk for at du bruker NRSS 🙏🌟 Vurder å støtte utviklingen via Vipps med omtrent det samme som prisen på en kaffekopp. Se mer på https://nrss.deno.dev/`;
+  const firstPromotion = `⬇️NRSS er avhengig av din Vipps-støtte⬇️`;
+  const secondPromotion = `Takk for at du bruker NRSS 🙏🌟 Vurder å støtte utviklingen via Vipps med omtrent det samme som prisen på en kaffekopp. Se mer på https://nrss.deno.dev/`;
 
-  return `${description}\n\n${promotion}`;
+  return `${firstPromotion}\n\n${description}\n\n${secondPromotion}`;
 }
 
 function assembleEpisode(episode: Episode, seriesId: Series["id"]): Tag {
@@ -76,10 +73,7 @@ function assembleEpisode(episode: Episode, seriesId: Series["id"]): Tag {
     tag("pubDate", new Date(episode.date).toUTCString()),
     tag("itunes:duration", episode.durationInSeconds.toString()),
     tag("podcast:chapters", "", [
-      [
-        "url",
-        `${getHostUrl()}/api/feeds/${seriesId}/${episode.id}/chapters`,
-      ],
+      ["url", `${getHostUrl()}/api/feeds/${seriesId}/${episode.id}/chapters`],
       ["type", "application/json+chapters"],
     ]),
     tag("enclosure", "", [

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -31,17 +31,15 @@ function assembleFeed(series: Series): string {
           tag("ttl", "60"), //60 minutes
           ...(series.imageUrl
             ? [
-                tag("itunes:image", "", [["href", series.imageUrl]]),
-                tag("image", [
-                  tag("url", series.imageUrl),
-                  tag("title", series.title),
-                  tag("link", series.link),
-                ]),
-              ]
+              tag("itunes:image", "", [["href", series.imageUrl]]),
+              tag("image", [
+                tag("url", series.imageUrl),
+                tag("title", series.title),
+                tag("link", series.link),
+              ]),
+            ]
             : []),
-          ...series.episodes.map((episode) =>
-            assembleEpisode(episode, series.id)
-          ),
+          ...series.episodes.map((episode) => assembleEpisode(episode, series.id)),
         ]),
       ],
       [
@@ -49,14 +47,15 @@ function assembleFeed(series: Series): string {
         ["xmlns:itunes", "http://www.itunes.com/dtds/podcast-1.0.dtd"],
         ["xmlns:content", "http://purl.org/rss/1.0/modules/content/"],
         ["xmlns:podcast", "https://podcastindex.org/namespace/1.0"],
-      ]
-    )
+      ],
+    ),
   );
 }
 
 function descriptionWithDonationPromotion(description: string): string {
   const firstPromotion = `⬇️NRSS er avhengig av din Vipps-støtte⬇️`;
-  const secondPromotion = `Takk for at du bruker NRSS 🙏🌟 Vurder å støtte utviklingen via Vipps med omtrent det samme som prisen på en kaffekopp. Se mer på https://nrss.deno.dev/`;
+  const secondPromotion =
+    `Takk for at du bruker NRSS 🙏🌟 Vurder å støtte utviklingen via Vipps med omtrent det samme som prisen på en kaffekopp. Se mer på https://nrss.deno.dev/`;
 
   return `${firstPromotion}\n\n${description}\n\n${secondPromotion}`;
 }


### PR DESCRIPTION
NRSS does not have enough supporters to break even and thus costs me
quite a bit every month. However, it seems to have a stable and high
user base, most of whom presumably could pay. As earlier, I'd like to
avoid shoving the service behind a paywall - that feels totally wrong
for what this project is supposed to be. This PR introduces another,
shorter link to donations _before_ the episode description in the
hopes of attracting more paid users. Let's see if it works :)

The last time there was a promo text at the start of the description,
@augustskare correctly pointed out that this hides the original description
from many views in podcast players in #34. That's not nice. I've tried to
acommodate this by making the initial description much shorter than
the one I had then (which now comes at the end).